### PR TITLE
Add Remove Restricted Products API

### DIFF
--- a/app/controllers/workarea/storefront/globale/api_controller.rb
+++ b/app/controllers/workarea/storefront/globale/api_controller.rb
@@ -43,6 +43,16 @@ module Workarea
           render json: @response.to_json
         end
 
+        # Remove products from the order marked as restricted on Global-E's side.
+        def remove_restricted_products
+          @job = GlobalE::Api::RemoveRestrictedProducts.perform(
+            @order,
+            params['RemovedProductCodes']
+          )
+
+          render json: @job.response
+        end
+
         private
 
           def api_error_response(error)

--- a/app/services/workarea/global_e/api/remove_restricted_products.rb
+++ b/app/services/workarea/global_e/api/remove_restricted_products.rb
@@ -1,0 +1,28 @@
+module Workarea
+  module GlobalE
+    module Api
+      class RemoveRestrictedProducts
+        attr_reader :order, :codes
+
+        def initialize(order, codes = [])
+          @order = order
+          @codes = codes
+        end
+
+        def self.perform(*args)
+          new(*args).tap(&:call)
+        end
+
+        def call
+          order.items.each do |item|
+            item.destroy if item.sku.in?(codes)
+          end
+        end
+
+        def response
+          @response ||= Merchant::ResponseInfo.new(order: order)
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Workarea::Storefront::Engine.routes.draw do
     post :receive_payment, controller: :api
     post :update_order_status, controller: :api
     post :receive_shipping_info, controller: :api
+    post :remove_restricted_products, controller: :api
     post :receive_order_refund, controller: :refund
   end
 end

--- a/test/integration/workarea/storefront/global_e_api/remove_restricted_products_integration_test.rb
+++ b/test/integration/workarea/storefront/global_e_api/remove_restricted_products_integration_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module Workarea
+  module Storefront
+    module GlobalEApi
+      class RemoveRestrictedProductsIntegrationTest < Workarea::IntegrationTest
+        include GlobalESupport
+
+        def test_successful_post
+          order = create_global_e_completed_checkout
+          path = storefront.globale_remove_restricted_products_path(
+            format: :json
+          )
+
+          post path, params: {
+            'MerchantGUID' => "abcdabcd-abcd-abcd-abcd-abcdabcdabcd",
+            'CartId' => order.global_e_token,
+            'RemovedProductCodes' => order.items.map(&:sku)
+          }
+
+          assert_empty(order.reload.items)
+          assert_response(:success)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows Global-E to `POST` any products in an order that should be
removed, since they are restricted in the given user's area.

GLOBALE-1