### PR TITLE
Add new fields for taxes and duties

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://gems.weblinc.com' do
   gem 'workarea-ci'
 end
 
-gem 'workarea-gift_cards', github: 'workarea-commerce/workarea-gift-cards', branch: 'GIFTCARDS-7-backport-missing-via-param' # '~> 3.4.7'
+gem 'workarea-gift_cards', github: 'workarea-commerce/workarea-gift-cards', :tag => 'v3.4.7'
 gem 'sprockets', '~> 3'
 
 gemspec

--- a/app/models/workarea/order.decorator
+++ b/app/models/workarea/order.decorator
@@ -18,6 +18,8 @@ module Workarea
       field :total_duties_price, type: Money
       field :international_total_price, type: Money
       field :contains_clearance_fees_price, type: Money
+      field :duties_and_taxes_nonsubsidized, type: Money
+      field :duties_and_taxes_subsidized, type: Money
 
       embeds_many :discount_adjustments,
         class_name: 'Workarea::PriceAdjustment',

--- a/app/services/workarea/global_e/api/send_order_to_merchant.rb
+++ b/app/services/workarea/global_e/api/send_order_to_merchant.rb
@@ -67,10 +67,26 @@ module Workarea
               total_price: order.items.sum(&:total_price) - order.discount_adjustments.sum { |pa| pa.amount.abs },
               international_total_price: international_total_price,
 
-              tax_total: total_duties_and_taxes_price,
+              duties_and_taxes_nonsubsidized: total_duties_and_taxes_price,
+              duties_and_taxes_subsidized: total_duties_and_taxes_subsidized,
+              tax_total: total_duties_and_taxes_price - total_duties_and_taxes_subsidized,
               total_duties_price: total_duties_price,
               contains_clearance_fees_price: contains_clearance_fees_price,
               duties_guaranteed: international_details.duties_guaranteed
+            )
+          end
+
+          def total_duties_and_taxes_price
+            Money.from_amount(
+              merchant_order.total_duties_and_taxes_price,
+              merchant_order.currency_code
+            )
+          end
+
+          def total_duties_and_taxes_subsidized
+            Money.from_amount(
+              merchant_order.discounts.select { |d| d.tax_subsidy? }.sum(&:price),
+              merchant_order.currency_code
             )
           end
 

--- a/app/services/workarea/global_e/merchant/discount.rb
+++ b/app/services/workarea/global_e/merchant/discount.rb
@@ -121,6 +121,10 @@ module Workarea
         def shipping?
           discount_type == 2
         end
+
+        def tax_subsidy?
+          discount_type == 4
+        end
       end
     end
   end

--- a/app/views/workarea/admin/orders/attributes.html.haml
+++ b/app/views/workarea/admin/orders/attributes.html.haml
@@ -126,6 +126,16 @@
                     %th
                       %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.shipping')
                     %td= number_to_currency @order.shipping_total
+                  - if @order.duties_and_taxes_nonsubsidized.present?
+                    %tr
+                      %th
+                        %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.duties_and_taxes_nonsubsidized')
+                      %td= number_to_currency @order.duties_and_taxes_nonsubsidized
+                  - if @order.duties_and_taxes_subsidized.present?
+                    %tr
+                      %th
+                        %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.duties_and_taxes_subsidized')
+                      %td= number_to_currency @order.duties_and_taxes_subsidized
                   %tr
                     %th
                       %span.data-pairs__name= t('workarea.admin.orders.attributes.totals.tax')

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -58,7 +58,10 @@ en:
         sale_price_default: "(defaults to regular)"
         title: Fixed prices for %{sku}
       orders:
-        attributs:
+        attributes:
+          totals:
+            duties_and_taxes_nonsubsidized: Total Duties and Taxes Owed
+            duties_and_taxes_subsidized: Tax Subsidization
           items:
             nonadjusted_pricing: Nonadjusted Pricing
         cards:

--- a/test/factories/workarea/global_e_factories.rb
+++ b/test/factories/workarea/global_e_factories.rb
@@ -574,7 +574,7 @@ module Workarea
         "MerchantOrderId" => nil,
         "PriceCoefficientRate" => 1.000000,
         "GenericHSCode" => nil,
-        "TotalDutiesAndTaxesPrice" => 0.0,
+        "TotalDutiesAndTaxesPrice" => 53.03,
         "CCFPrice" => 0.0
       }.to_json
     end

--- a/test/integration/workarea/storefront/global_e_api/receive_order_integration_test.rb
+++ b/test/integration/workarea/storefront/global_e_api/receive_order_integration_test.rb
@@ -225,6 +225,22 @@ module Workarea
           assert_equal 1, order.international_discount_adjustments.size
         end
 
+        def test_with_tax_subsidy_discount
+          order = create_cart
+
+          post storefront.globale_receive_order_path,
+            headers: { 'CONTENT_TYPE' => 'application/json' },
+            params: global_e_send_order_to_merchant_with_shipping_discounts_body(order: order)
+
+          assert response.ok?, "Expected 200 response"
+
+          order.reload
+
+          assert_equal "$53.03", order.duties_and_taxes_nonsubsidized.format
+          assert_equal "$53.03", order.duties_and_taxes_subsidized.format
+          assert_equal "$0.00", order.tax_total.format
+        end
+
         def test_updating_user_addresses
           user = create_user(
             addresses: [


### PR DESCRIPTION
- Adds duties_and_taxes_nonsubsidized and duties_and_taxes_subsidized to orders
- Tax total for global e orders are now defined as duties_and_taxes_nonsubsidized - duties_and_taxes_subsidized
- The two new fields are added to the attribute view of admin for orders